### PR TITLE
Fix RPData tip crash. 

### DIFF
--- a/StreetHawk/Classes/Core/Internal/SHUtils.m
+++ b/StreetHawk/Classes/Core/Internal/SHUtils.m
@@ -398,6 +398,7 @@ UIWindow *shGetPresentWindow()
 #pragma mark - Resources and Bundles Utility
 
 #define StreetHawk_BUNDLE ([[NSBundle mainBundle] URLForResource:@"streethawk" withExtension:@"bundle"] != nil ? [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"streethawk" withExtension:@"bundle"]] : nil)
+#define Pointzi_BUNDLE ([[NSBundle mainBundle] URLForResource:@"Pointzi" withExtension:@"bundle"] != nil ? [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"Pointzi" withExtension:@"bundle"]] : nil)
 #define StreetHawkCoreRES_BUNDLE ([[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle"] != nil ? [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle"]] : nil)
 #define StreetHawkCoreRES_Titanium_BUNDLE ([[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle" subdirectory:@"modules/com.streethawk.shanalytics"] != nil ? [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle" subdirectory:@"modules/com.streethawk.shanalytics"]] : nil)
 #define StreetHawkCoreRES_EmbeddedFull_BUNDLE ([[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle" subdirectory:@"Frameworks/StreetHawkCore.framework"] != nil ? [NSBundle bundleWithURL:[[NSBundle mainBundle] URLForResource:@"StreetHawkCoreRes" withExtension:@"bundle" subdirectory:@"Frameworks/StreetHawkCore.framework"]] : nil)
@@ -412,6 +413,10 @@ NSBundle *shFindBundleForResource(NSString *resourceName, NSString *type, BOOL m
     else if (StreetHawk_BUNDLE != nil && [[NSFileManager defaultManager] fileExistsAtPath:[StreetHawk_BUNDLE pathForResource:resourceName ofType:type]]) //check streethawk.bundle
     {
         bundle = StreetHawk_BUNDLE;
+    }
+    else if (Pointzi_BUNDLE != nil && [[NSFileManager defaultManager] fileExistsAtPath:[Pointzi_BUNDLE pathForResource:resourceName ofType:type]]) //check Pointzi.bundle
+    {
+        bundle = Pointzi_BUNDLE;
     }
     else if (StreetHawkCoreRES_BUNDLE != nil && [[NSFileManager defaultManager] fileExistsAtPath:[StreetHawkCoreRES_BUNDLE pathForResource:resourceName ofType:type]])  //check StreetHawkCoreRes.bundle
     {
@@ -452,6 +457,10 @@ NSString *shLocalizedString(NSString *key, NSString *defaultStr)
         if (StreetHawk_BUNDLE != nil)
         {
             retStr = NSLocalizedStringWithDefaultValue(key, nil, StreetHawk_BUNDLE, defaultStr, nil);
+        }
+        if (Pointzi_BUNDLE != nil)
+        {
+            retStr = NSLocalizedStringWithDefaultValue(key, nil, Pointzi_BUNDLE, defaultStr, nil);
         }
         if (StreetHawkCoreRES_BUNDLE != nil && (shStrIsEmpty(retStr) || [retStr isEqualToString:key]))
         {

--- a/StreetHawk/Classes/Core/Publish/SHBaseViewController.m
+++ b/StreetHawk/Classes/Core/Publish/SHBaseViewController.m
@@ -270,7 +270,13 @@ typedef void (^SHCoverViewTouched) (CGPoint touchPoint);
             self.coverView.overlayColor = coverColor;
             self.coverView.overlayAlpha = coverAlpha;
             self.coverView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight; //make cover always full screen during rotation.
-            [rootVC.view addSubview:self.coverView];
+            UIViewController *presentedVC = rootVC;
+            while (presentedVC.presentedViewController != nil)
+            {
+                presentedVC = presentedVC.presentedViewController;
+            }
+            [presentedVC.view addSubview:self.coverView];
+//            [[UIApplication sharedApplication].keyWindow addSubview:self.coverView]; //this also work but cannot rotate
             self.view.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin; //content vc by default always in center, not affected by rotatation.
             [self.coverView addSubview:self.view];
             if (coverTouchHandler != nil)


### PR DESCRIPTION
In pod project the resource xib files are packaged into Pointzi.bundle, and not in directly main bundle. This cause the xib file cannot be find and fail to init tip.