### PR TITLE
Android503 supertagmd5

### DIFF
--- a/StreetHawk/Classes/Core/Publish/SHUtils.h
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.h
@@ -322,4 +322,13 @@ extern NSString *shCaptureAdvertisingIdentifier();
 
 @end
 
+@interface NSString (SHExt)
+
+/**
+ Get md5 of a string.
+ */
+- (NSString *)md5;
+
+@end
+
 #endif //SH__UTILS__H

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -1026,3 +1026,22 @@ static NSString *getPropertyType(objc_property_t property)
 }
 
 @end
+
+#import <CommonCrypto/CommonDigest.h>
+
+@implementation NSString (SHExt)
+
+- (NSString *)md5
+{
+    const char *cStr = [[NSData dataWithContentsOfFile:self] bytes];
+    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    NSInteger length = [[NSData dataWithContentsOfFile:self] length]; // strlen(cStr);
+    CC_MD5(cStr, (int)length, result);
+    return [NSString stringWithFormat:
+            @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+            result[0], result[1], result[2], result[3], result[4], result[5],
+            result[6], result[7], result[8], result[9], result[10], result[11],
+            result[12], result[13], result[14], result[15]];
+}
+
+@end

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -1033,9 +1033,9 @@ static NSString *getPropertyType(objc_property_t property)
 
 - (NSString *)md5
 {
-    const char *cStr = [[NSData dataWithContentsOfFile:self] bytes];
+    const char *cStr = [self cStringUsingEncoding:NSUTF8StringEncoding];
     unsigned char result[CC_MD5_DIGEST_LENGTH];
-    NSInteger length = [[NSData dataWithContentsOfFile:self] length]; // strlen(cStr);
+    NSInteger length = strlen(cStr);
     CC_MD5(cStr, (int)length, result);
     return [NSString stringWithFormat:
             @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",

--- a/StreetHawk/Classes/Crash/Private/SHCrashBridge.m
+++ b/StreetHawk/Classes/Crash/Private/SHCrashBridge.m
@@ -21,7 +21,6 @@
 #import "SHCrashHandler.h"
 #import "SHUtils.h" //for SHLog
 //header from System
-#import <CommonCrypto/CommonDigest.h>
 #import <mach/mach.h>
 #import <mach/mach_host.h>
 
@@ -29,7 +28,6 @@
 
 + (void)createCrashHandler:(NSNotification *)notification; //for creating crash handler when register. notification name: SH_CrashBridge_CreateObject; user info: empty.
 + (void)installUpdateSucceededForCrash:(NSNotification *)notification; //Handle install update notification for sending crash report.
-+ (NSString*)getMD5Checksum:(NSString*)content; //Get MD5 of a string
 
 @end
 
@@ -95,7 +93,7 @@
         NSString *infoStr = [NSString stringWithFormat:@"CrashReporter Key:   %@, %@, %@, %@, Battery %@, Memory: %@", shDevelopmentPlatformString(), shAppModeString(shAppMode()), StreetHawk.version, StreetHawk.currentInstall.suid, battery, memoryUsage];
         crashReport = [crashReport stringByReplacingOccurrencesOfString:@"CrashReporter Key:   " withString:infoStr];
         //store MD5 in NSUserDefaults and compare with next send to avoid double reporting of crashlogs
-        NSString *md5 = [self getMD5Checksum:crashReport];
+        NSString *md5 = [crashReport md5];
         NSString *previousSend = [[NSUserDefaults standardUserDefaults] objectForKey:@"CrashLog_MD5"];
         if (previousSend != md5)
         {
@@ -115,16 +113,6 @@
             [StreetHawk.crashHandler purgePendingCrashReport]; //Same as before, purge local.
         }
     }
-}
-
-+ (NSString*)getMD5Checksum:(NSString*)content
-{
-    const char *cStr = [[NSData dataWithContentsOfFile:content] bytes];
-    unsigned char result[CC_MD5_DIGEST_LENGTH];
-    NSInteger length = [[NSData dataWithContentsOfFile:content] length]; // strlen(cStr);
-    CC_MD5(cStr, (int)length, result);
-    return [NSString stringWithFormat:
-            @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", result[0], result[1], result[2], result[3], result[4], result[5], result[6], result[7], result[8], result[9], result[10], result[11], result[12], result[13], result[14], result[15]];
 }
 
 @end


### PR DESCRIPTION
Crash module has md5 function. Move this function to Core/Util so that it can be used for both Crash module and Pointzi module. 