### PR TITLE
Fix IOS-1122: Preview feed fetch should use last tip modified time no…

### DIFF
--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -109,50 +109,26 @@ NSDate *shParseDate(NSString *input, int offsetSeconds)
         dispatch_semaphore_wait(formatter_semaphore, DISPATCH_TIME_FOREVER);
         NSDateFormatter *dateFormatter = shGetDateFormatter(nil, nil, nil);
         out = [dateFormatter dateFromString:input];
+        NSArray *arrayTimeformat = @[@"yyyy-MM-dd'T'HH:mm:ss.SSS",
+                                     @"yyyy-MM-dd'T'HH:mm:ssZ",
+                                     @"yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+                                     @"yyyy-MM-dd'T'HH:mm:ss",
+                                     @"yyyy-MM-dd",
+                                     @"dd/MM/yyyy HH:mm:ss",
+                                     @"dd/MM/yyyy",
+                                     @"MM/dd/yyyy HH:mm:ss",
+                                     @"MM/dd/yyyy"];
         if (out == nil)
         {
-            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"yyyy-MM-dd"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"dd/MM/yyyy HH:mm:ss"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"dd/MM/yyyy"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"MM/dd/yyyy HH:mm:ss"];
-            out = [dateFormatter dateFromString:input];
-        }
-        if (out == nil)
-        {
-            [dateFormatter setDateFormat:@"MM/dd/yyyy"];
-            out = [dateFormatter dateFromString:input];
+            for (NSString *strTimeFormat in arrayTimeformat)
+            {
+                [dateFormatter setDateFormat:strTimeFormat];
+                out = [dateFormatter dateFromString:input];
+                if (out != nil)
+                {
+                    break;
+                }
+            }
         }
         dispatch_semaphore_signal(formatter_semaphore);
         if (offsetSeconds != 0)

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -121,6 +121,11 @@ NSDate *shParseDate(NSString *input, int offsetSeconds)
         }
         if (out == nil)
         {
+            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+            out = [dateFormatter dateFromString:input];
+        }
+        if (out == nil)
+        {
             [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
             out = [dateFormatter dateFromString:input];
         }


### PR DESCRIPTION
…t device time

Feed’s modified time uses a new format. SDK side add supporting format.