### PR TITLE
Fix IOS-1151: Wikipedia_demo's tour doesn't disappear

### DIFF
--- a/StreetHawk/Classes/Core/Internal/SHCoverView.m
+++ b/StreetHawk/Classes/Core/Internal/SHCoverView.m
@@ -111,8 +111,7 @@
     {
         if (self.touchedHandler)
         {
-            CGPoint touchLocation = [[[event allTouches] anyObject] locationInView:self];
-            self.touchedHandler(touchLocation);
+            self.touchedHandler([[[event allTouches] anyObject] locationInView:self]);
         }
     }
     else

--- a/StreetHawk/Classes/Core/Internal/SHCoverView.m
+++ b/StreetHawk/Classes/Core/Internal/SHCoverView.m
@@ -104,11 +104,21 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event
 {
     [super touchesBegan:touches withEvent:event];
-    if (self.touchedHandler)
+    //A safety precautions: this view is dim cover used for tip.
+    //In case there is no tip available, the dim cover should be able to dismiss itself.
+    //Check whether the dim cover has tip on it, if not, just remove it so that it won't stuck customer.
+    if (self.subviews.count > 0)
     {
-        UITouch *touch = [[event allTouches] anyObject];
-        CGPoint touchLocation = [touch locationInView:self];
-        self.touchedHandler(touchLocation);
+        if (self.touchedHandler)
+        {
+            UITouch *touch = [[event allTouches] anyObject];
+            CGPoint touchLocation = [touch locationInView:self];
+            self.touchedHandler(touchLocation);
+        }
+    }
+    else
+    {
+        [self removeFromSuperview];
     }
 }
 

--- a/StreetHawk/Classes/Core/Internal/SHCoverView.m
+++ b/StreetHawk/Classes/Core/Internal/SHCoverView.m
@@ -111,8 +111,7 @@
     {
         if (self.touchedHandler)
         {
-            UITouch *touch = [[event allTouches] anyObject];
-            CGPoint touchLocation = [touch locationInView:self];
+            CGPoint touchLocation = [[[event allTouches] anyObject] locationInView:self];
             self.touchedHandler(touchLocation);
         }
     }


### PR DESCRIPTION
A safety precautions: this view is dim cover used for tip. In case there is no tip available, the dim cover should be able to dismiss itself. Check whether the dim cover has tip on it, if not, just remove it so that it won't stuck customer.