### PR TITLE
Fix IOS-1101:  Make autoIntegration = NO; by default in Pointzi

### DIFF
--- a/StreetHawk/Classes/Core/Publish/SHApp.m
+++ b/StreetHawk/Classes/Core/Publish/SHApp.m
@@ -257,7 +257,7 @@
         //some handlers initialize erlier
         self.installHandler = [[SHInstallHandler alloc] init];
 
-        self.autoIntegrateAppDelegate = YES;
+        self.autoIntegrateAppDelegate = NO;
         [self setupNotifications]; //move early so that Phonegap can handle remote notification in appDidFinishLaunching.
     }
     return self;


### PR DESCRIPTION
Make StreetHawk.autoIntegration = NO to avoid potential crash which NowHealth and RPData met. As Pointzi has easy enter/exit, it doesn’t need this any more.