### PR TITLE
Fix IOS-1189:  image background color #fff vs #ffffff vs rgb(255,255,…

### DIFF
--- a/Example_StaticLibrary/StreetHawkDemo.xcodeproj/project.pbxproj
+++ b/Example_StaticLibrary/StreetHawkDemo.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-StreetHawkDemo/Pods-StreetHawkDemo-resources.sh",
-				$PODS_CONFIGURATION_BUILD_DIR/streethawk/streethawk.bundle,
+				"${PODS_CONFIGURATION_BUILD_DIR}/streethawk/streethawk.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (

--- a/StreetHawk/Classes/Core/Publish/SHUtils.h
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.h
@@ -297,9 +297,12 @@ extern NSString *shCaptureAdvertisingIdentifier(void);
 #define AARRGGBB_COLOUR_CODE_LEN    8
 
 /**
- Convert hex string formatted as #RRGGBB or #AARRGGBB to UIColor. It must prefix "#" and only contains (A), R, G, B. If not in this format, return nil.
+ Support two types:
+ 1. Convert hex string formatted as #RGB or #RRGGBB or #AARRGGBB to UIColor.
+    It must prefix "#" and only contains (A), R, G, B. If not in this format, return nil.
+ 2. Convert RGB string formatted as rgb(255,255,255,1).
  */
-+ (UIColor *)colorFromHexString:(NSString *)hexString;
++ (UIColor *)colorFromString:(NSString *)str;
 
 /**
  Convert color to hex string formatted as #AARRGGBB. If color is nil return nil.

--- a/StreetHawk/Classes/Core/Publish/SHUtils.h
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.h
@@ -291,6 +291,11 @@ extern NSString *shCaptureAdvertisingIdentifier(void);
  */
 @interface UIColor (SHExt)
 
+#define RGB_COLOUR_CODE_LEN         3
+#define ARGB_COLOUR_CODE_LEN        4
+#define RRGGBB_COLOUR_CODE_LEN      6
+#define AARRGGBB_COLOUR_CODE_LEN    8
+
 /**
  Convert hex string formatted as #RRGGBB or #AARRGGBB to UIColor. It must prefix "#" and only contains (A), R, G, B. If not in this format, return nil.
  */

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -865,19 +865,16 @@ NSString *shCaptureAdvertisingIdentifier()
 
 + (BOOL)isRGB:(NSArray *)arrayComponents
 {
-    return arrayComponents.count >= 3;
+    return arrayComponents.count >= RGB_COLOUR_CODE_LEN;
 }
 
 + (BOOL)isRGBA:(NSArray *)arrayComponents
 {
-    return arrayComponents.count == 4;
+    return arrayComponents.count == ARGB_COLOUR_CODE_LEN;
 }
 
 + (UIColor *)colorFromHexString:(NSString *)hexString
 {
-    const NSInteger RGB_COLOUR_CODE_LEN = 4;
-    const NSInteger RRGGBB_COLOUR_CODE_LEN = 7;
-    const NSInteger AARRGGBB_COLOUR_CODE_LEN = 9;
     if (![hexString isKindOfClass:[NSString class]])
     {
         return nil;
@@ -886,15 +883,15 @@ NSString *shCaptureAdvertisingIdentifier()
     CGFloat green = -1;
     CGFloat blue = -1;
     CGFloat alpha = -1;
-    if (hexString.length == RGB_COLOUR_CODE_LEN //#RGB
-        || hexString.length == RRGGBB_COLOUR_CODE_LEN //#RRGGBB
-        || hexString.length == AARRGGBB_COLOUR_CODE_LEN) //#AARRGGBB
+    if (hexString.length == RGB_COLOUR_CODE_LEN + 1 //#RGB
+        || hexString.length == RRGGBB_COLOUR_CODE_LEN + 1 //#RRGGBB
+        || hexString.length == AARRGGBB_COLOUR_CODE_LEN + 1) //#AARRGGBB
     {
         if (![hexString hasPrefix:@"#"])
         {
             return nil;
         }
-        if (hexString.length == RGB_COLOUR_CODE_LEN)
+        if (hexString.length == RGB_COLOUR_CODE_LEN + 1)
         {
             NSString *red = [hexString substringWithRange:NSMakeRange(1, 1)];
             NSString *green = [hexString substringWithRange:NSMakeRange(2, 1)];
@@ -908,7 +905,7 @@ NSString *shCaptureAdvertisingIdentifier()
         red = ((rgbValue & 0xFF0000) >> 16)/255.0;
         green = ((rgbValue & 0xFF00) >> 8)/255.0;
         blue = (rgbValue & 0xFF)/255.0;
-        if (hexString.length == RRGGBB_COLOUR_CODE_LEN)
+        if (hexString.length == RRGGBB_COLOUR_CODE_LEN + 1)
         {
             alpha = 1.0;
         }

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -865,6 +865,11 @@ NSString *shCaptureAdvertisingIdentifier()
 
 + (UIColor *)colorFromHexString:(NSString *)hexString
 {
+    const NSInteger RGB = 4;
+    const NSInteger RRGGBB = 7;
+    const NSInteger AARRGGBB = 9;
+    const NSInteger COMPONENTRGB = 3;
+    const NSInteger COMPONENTARGB = 4;
     if (![hexString isKindOfClass:[NSString class]])
     {
         return nil;
@@ -873,15 +878,15 @@ NSString *shCaptureAdvertisingIdentifier()
     CGFloat green = -1;
     CGFloat blue = -1;
     CGFloat alpha = -1;
-    if (hexString.length == 4 //#RGB
-        || hexString.length == 7 //#RRGGBB
-        || hexString.length == 9) //#AARRGGBB
+    if (hexString.length == RGB //#RGB
+        || hexString.length == RRGGBB //#RRGGBB
+        || hexString.length == AARRGGBB) //#AARRGGBB
     {
         if (![hexString hasPrefix:@"#"])
         {
             return nil;
         }
-        if (hexString.length == 4)
+        if (hexString.length == RGB)
         {
             NSString *red = [hexString substringWithRange:NSMakeRange(1, 1)];
             NSString *green = [hexString substringWithRange:NSMakeRange(2, 1)];
@@ -895,7 +900,7 @@ NSString *shCaptureAdvertisingIdentifier()
         red = ((rgbValue & 0xFF0000) >> 16)/255.0;
         green = ((rgbValue & 0xFF00) >> 8)/255.0;
         blue = (rgbValue & 0xFF)/255.0;
-        if (hexString.length == 7)
+        if (hexString.length == RRGGBB)
         {
             alpha = 1.0;
         }
@@ -913,13 +918,13 @@ NSString *shCaptureAdvertisingIdentifier()
             hexString = [hexString stringByReplacingOccurrencesOfString:@"rgb(" withString:@""];
             hexString = [hexString stringByReplacingOccurrencesOfString:@")" withString:@""];
             NSArray *arrayComponents = [hexString componentsSeparatedByString:@","];
-            if (arrayComponents.count >= 3)
+            if (arrayComponents.count >= COMPONENTRGB)
             {
                 red = [arrayComponents[0] floatValue]/255.0;
                 green = [arrayComponents[1] floatValue]/255.0;
                 blue = [arrayComponents[2] floatValue]/255.0;
             }
-            if (arrayComponents.count == 4)
+            if (arrayComponents.count == COMPONENTARGB)
             {
                 alpha = [arrayComponents[3] floatValue];
                 if (alpha > 1)

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -863,13 +863,21 @@ NSString *shCaptureAdvertisingIdentifier()
 
 @implementation UIColor (SHExt)
 
++ (BOOL)isRGB:(NSArray *)arrayComponents
+{
+    return arrayComponents.count >= 3;
+}
+
++ (BOOL)isRGBA:(NSArray *)arrayComponents
+{
+    return arrayComponents.count == 4;
+}
+
 + (UIColor *)colorFromHexString:(NSString *)hexString
 {
     const NSInteger RGB_COLOUR_CODE_LEN = 4;
     const NSInteger RRGGBB_COLOUR_CODE_LEN = 7;
     const NSInteger AARRGGBB_COLOUR_CODE_LEN = 9;
-    const NSInteger IS_RGB = 3;
-    const NSInteger IS_RGBA = 4;
     if (![hexString isKindOfClass:[NSString class]])
     {
         return nil;
@@ -918,13 +926,13 @@ NSString *shCaptureAdvertisingIdentifier()
             hexString = [hexString stringByReplacingOccurrencesOfString:@"rgb(" withString:@""];
             hexString = [hexString stringByReplacingOccurrencesOfString:@")" withString:@""];
             NSArray *arrayComponents = [hexString componentsSeparatedByString:@","];
-            if (arrayComponents.count >= IS_RGB)
+            if ([self isRGB:arrayComponents])
             {
                 red = [arrayComponents[0] floatValue]/255.0;
                 green = [arrayComponents[1] floatValue]/255.0;
                 blue = [arrayComponents[2] floatValue]/255.0;
             }
-            if (arrayComponents.count == IS_RGBA)
+            if ([self isRGBA:arrayComponents])
             {
                 alpha = [arrayComponents[3] floatValue];
                 if (alpha > 1)

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -865,11 +865,11 @@ NSString *shCaptureAdvertisingIdentifier()
 
 + (UIColor *)colorFromHexString:(NSString *)hexString
 {
-    const NSInteger RGB = 4;
-    const NSInteger RRGGBB = 7;
-    const NSInteger AARRGGBB = 9;
-    const NSInteger COMPONENTRGB = 3;
-    const NSInteger COMPONENTARGB = 4;
+    const NSInteger RGB_COLOUR_CODE_LEN = 4;
+    const NSInteger RRGGBB_COLOUR_CODE_LEN = 7;
+    const NSInteger AARRGGBB_COLOUR_CODE_LEN = 9;
+    const NSInteger IS_RGB = 3;
+    const NSInteger IS_RGBA = 4;
     if (![hexString isKindOfClass:[NSString class]])
     {
         return nil;
@@ -878,15 +878,15 @@ NSString *shCaptureAdvertisingIdentifier()
     CGFloat green = -1;
     CGFloat blue = -1;
     CGFloat alpha = -1;
-    if (hexString.length == RGB //#RGB
-        || hexString.length == RRGGBB //#RRGGBB
-        || hexString.length == AARRGGBB) //#AARRGGBB
+    if (hexString.length == RGB_COLOUR_CODE_LEN //#RGB
+        || hexString.length == RRGGBB_COLOUR_CODE_LEN //#RRGGBB
+        || hexString.length == AARRGGBB_COLOUR_CODE_LEN) //#AARRGGBB
     {
         if (![hexString hasPrefix:@"#"])
         {
             return nil;
         }
-        if (hexString.length == RGB)
+        if (hexString.length == RGB_COLOUR_CODE_LEN)
         {
             NSString *red = [hexString substringWithRange:NSMakeRange(1, 1)];
             NSString *green = [hexString substringWithRange:NSMakeRange(2, 1)];
@@ -900,7 +900,7 @@ NSString *shCaptureAdvertisingIdentifier()
         red = ((rgbValue & 0xFF0000) >> 16)/255.0;
         green = ((rgbValue & 0xFF00) >> 8)/255.0;
         blue = (rgbValue & 0xFF)/255.0;
-        if (hexString.length == RRGGBB)
+        if (hexString.length == RRGGBB_COLOUR_CODE_LEN)
         {
             alpha = 1.0;
         }
@@ -918,13 +918,13 @@ NSString *shCaptureAdvertisingIdentifier()
             hexString = [hexString stringByReplacingOccurrencesOfString:@"rgb(" withString:@""];
             hexString = [hexString stringByReplacingOccurrencesOfString:@")" withString:@""];
             NSArray *arrayComponents = [hexString componentsSeparatedByString:@","];
-            if (arrayComponents.count >= COMPONENTRGB)
+            if (arrayComponents.count >= IS_RGB)
             {
                 red = [arrayComponents[0] floatValue]/255.0;
                 green = [arrayComponents[1] floatValue]/255.0;
                 blue = [arrayComponents[2] floatValue]/255.0;
             }
-            if (arrayComponents.count == COMPONENTARGB)
+            if (arrayComponents.count == IS_RGBA)
             {
                 alpha = [arrayComponents[3] floatValue];
                 if (alpha > 1)

--- a/StreetHawk/Classes/Core/Publish/SHUtils.m
+++ b/StreetHawk/Classes/Core/Publish/SHUtils.m
@@ -875,7 +875,7 @@ NSString *shCaptureAdvertisingIdentifier()
 
 + (UIColor *)colorFromHexString:(NSString *)hexString
 {
-    if (![hexString isKindOfClass:[NSString class]])
+    if (![hexString hasPrefix:@"#"])
     {
         return nil;
     }
@@ -883,67 +883,32 @@ NSString *shCaptureAdvertisingIdentifier()
     CGFloat green = -1;
     CGFloat blue = -1;
     CGFloat alpha = -1;
-    if (hexString.length == RGB_COLOUR_CODE_LEN + 1 //#RGB
-        || hexString.length == RRGGBB_COLOUR_CODE_LEN + 1 //#RRGGBB
-        || hexString.length == AARRGGBB_COLOUR_CODE_LEN + 1) //#AARRGGBB
+    if (hexString.length == RGB_COLOUR_CODE_LEN + 1)
     {
-        if (![hexString hasPrefix:@"#"])
-        {
-            return nil;
-        }
-        if (hexString.length == RGB_COLOUR_CODE_LEN + 1)
-        {
-            NSString *red = [hexString substringWithRange:NSMakeRange(1, 1)];
-            NSString *green = [hexString substringWithRange:NSMakeRange(2, 1)];
-            NSString *blue = [hexString substringWithRange:NSMakeRange(3, 1)];
-            hexString = [NSString stringWithFormat:@"#%@%@%@%@%@%@", red, red, green, green, blue, blue];
-        }
-        NSScanner *scanner = [NSScanner scannerWithString:hexString];
-        [scanner setScanLocation:1]; // bypass '#' character
-        unsigned rgbValue = 0;
-        [scanner scanHexInt:&rgbValue];
-        red = ((rgbValue & 0xFF0000) >> 16)/255.0;
-        green = ((rgbValue & 0xFF00) >> 8)/255.0;
-        blue = (rgbValue & 0xFF)/255.0;
-        if (hexString.length == RRGGBB_COLOUR_CODE_LEN + 1)
-        {
-            alpha = 1.0;
-        }
-        else
-        {
-            alpha = ((rgbValue & 0xFF000000) >> 24)/255.0;
-        }
+        NSString *red = [hexString substringWithRange:NSMakeRange(1, 1)];
+        NSString *green = [hexString substringWithRange:NSMakeRange(2, 1)];
+        NSString *blue = [hexString substringWithRange:NSMakeRange(3, 1)];
+        hexString = [NSString stringWithFormat:@"#%@%@%@%@%@%@", red, red, green, green, blue, blue];
+    }
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    unsigned rgbValue = 0;
+    [scanner scanHexInt:&rgbValue];
+    red = ((rgbValue & 0xFF0000) >> 16)/255.0;
+    green = ((rgbValue & 0xFF00) >> 8)/255.0;
+    blue = (rgbValue & 0xFF)/255.0;
+    if (hexString.length == RRGGBB_COLOUR_CODE_LEN + 1)
+    {
+        alpha = 1.0;
     }
     else
     {
-        //rgb(255,255,255,1)
-        if ([hexString.lowercaseString hasPrefix:@"rgb("]
-            && [hexString.lowercaseString hasSuffix:@")"])
-        {
-            hexString = [hexString stringByReplacingOccurrencesOfString:@"rgb(" withString:@""];
-            hexString = [hexString stringByReplacingOccurrencesOfString:@")" withString:@""];
-            NSArray *arrayComponents = [hexString componentsSeparatedByString:@","];
-            if ([self isRGB:arrayComponents])
-            {
-                red = [arrayComponents[0] floatValue]/255.0;
-                green = [arrayComponents[1] floatValue]/255.0;
-                blue = [arrayComponents[2] floatValue]/255.0;
-            }
-            if ([self isRGBA:arrayComponents])
-            {
-                alpha = [arrayComponents[3] floatValue];
-                if (alpha > 1)
-                {
-                    alpha = alpha/255.0;
-                }
-            }
-            else
-            {
-                alpha = 1.0;
-            }
-        }
+        alpha = ((rgbValue & 0xFF000000) >> 24)/255.0;
     }
-    if (red >= 0 && red <= 1 && green >= 0 && green <= 1 && blue >= 0 && blue <= 1 && alpha >= 0 && alpha <= 1)
+    if (red >= 0 && red <= 1
+        && green >= 0 && green <= 1
+        && blue >= 0 && blue <= 1
+        && alpha >= 0 && alpha <= 1)
     {
         return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
     }
@@ -951,6 +916,70 @@ NSString *shCaptureAdvertisingIdentifier()
     {
         return nil;
     }
+}
+
++ (UIColor *)colorFromRGBString:(NSString *)rgbString
+{
+    CGFloat red = -1;
+    CGFloat green = -1;
+    CGFloat blue = -1;
+    CGFloat alpha = -1;
+    if ([rgbString.lowercaseString hasPrefix:@"rgb("]
+        && [rgbString.lowercaseString hasSuffix:@")"])
+    {
+        rgbString = [rgbString.lowercaseString stringByReplacingOccurrencesOfString:@"rgb(" withString:@""];
+        rgbString = [rgbString stringByReplacingOccurrencesOfString:@")" withString:@""];
+        NSArray *arrayComponents = [rgbString componentsSeparatedByString:@","];
+        NSCharacterSet *whiteChar = [NSCharacterSet whitespaceCharacterSet];
+        if ([self isRGB:arrayComponents])
+        {
+            red = [[arrayComponents[0] stringByTrimmingCharactersInSet:whiteChar] floatValue]/255.0;
+            green = [[arrayComponents[1] stringByTrimmingCharactersInSet:whiteChar] floatValue]/255.0;
+            blue = [[arrayComponents[2] stringByTrimmingCharactersInSet:whiteChar] floatValue]/255.0;
+        }
+        if ([self isRGBA:arrayComponents])
+        {
+            alpha = [[arrayComponents[3] stringByTrimmingCharactersInSet:whiteChar] floatValue];
+            if (alpha > 1)
+            {
+                alpha = alpha/255.0;
+            }
+        }
+        else
+        {
+            alpha = 1.0;
+        }
+    }
+    if (red >= 0 && red <= 1
+        && green >= 0 && green <= 1
+        && blue >= 0 && blue <= 1
+        && alpha >= 0 && alpha <= 1)
+    {
+        return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+    }
+    else
+    {
+        return nil;
+    }
+}
+
++ (UIColor *)colorFromString:(NSString *)str
+{
+    if (![str isKindOfClass:[NSString class]])
+    {
+        return nil;
+    }
+    if (str.length == RGB_COLOUR_CODE_LEN + 1 //#RGB
+        || str.length == RRGGBB_COLOUR_CODE_LEN + 1 //#RRGGBB
+        || str.length == AARRGGBB_COLOUR_CODE_LEN + 1) //#AARRGGBB
+    {
+        return [self colorFromHexString:str];
+    }
+    else //rgb(255,255,255,1)
+    {
+        return [self colorFromRGBString:str];
+    }
+    return nil;
 }
 
 + (NSString *)hexStringFromColor:(UIColor *)color


### PR DESCRIPTION
…255,1)

Support color format rgb(255,255,255,1) by parsing red, green, blue and alpha.