### PR TITLE
Fix IOS-1230:  Crash when set step id to be number

### DIFF
--- a/StreetHawk/Classes/Feed/Publish/SHApp+Feed.m
+++ b/StreetHawk/Classes/Feed/Publish/SHApp+Feed.m
@@ -149,6 +149,10 @@
     dictResult[@"status"] = resultStr;
     dictResult[@"feed_delete"] = @(feedDelete);
     dictResult[@"complete"] = @(complete);
+    if (![stepId isKindOfClass:[NSString class]])
+    {
+        stepId = [NSString stringWithFormat:@"%@", stepId];
+    }
     if (!shStrIsEmpty(stepId))
     {
         dictResult[@"step_id"] = stepId;


### PR DESCRIPTION
Check step id type and if it’s not string, covert it into string type.