### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ rm -Rf $BUILD_OUTPUTS/*
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
+security unlock-keychain $BUILD_PASSWORD
+
 # ------------------- build SHStatic ------------------------
 
 pushd .


### PR DESCRIPTION
Unlock keychain before xcodebuild archive.