### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,6 @@ rm -Rf $BUILD_OUTPUTS/*
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
-security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
-
 # ------------------- build SHStatic ------------------------
 
 pushd .

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ rm -Rf $BUILD_OUTPUTS/*
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
-security unlock-keychain $BUILD_PASSWORD
+security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
 
 # ------------------- build SHStatic ------------------------
 


### PR DESCRIPTION
Unlock keychain before xcodebuild archive.