### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ rm -Rf $BUILD_OUTPUTS/*
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
+security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
+
 # ------------------- build SHStatic ------------------------
 
 pushd .


### PR DESCRIPTION
Adding in salt doesn’t work. Change in build script again.