### PR TITLE
Fix ticket IOS-1249: Make sure log bundle size limit is respected

### DIFF
--- a/StreetHawk/Classes/Core/Internal/SHLogger.m
+++ b/StreetHawk/Classes/Core/Internal/SHLogger.m
@@ -500,7 +500,9 @@ enum
 - (NSMutableArray *)loadLogRecords
 {
     NSMutableArray *logRecords = [NSMutableArray array];
-    NSString *select_sql_str = [NSString stringWithFormat:@"SELECT * from '%@' WHERE status = 0 ORDER BY logid", tableName];
+    NSString *select_sql_str = [NSString stringWithFormat:@"SELECT * from '%@' WHERE status = 0 ORDER BY logid LIMIT %d",
+                                tableName,
+                                LOG_UPLOAD_INTERVAL];
     @synchronized(self)
     {
         sqlite3_stmt *select_sql = NULL;


### PR DESCRIPTION
Add “LIMIT” in sql to make sure select no more than 50 logs.